### PR TITLE
实现多roots的设置需求

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,24 @@ import { CLI, Shim } from 'clime';
 // The second parameter is the path to folder that contains command modules.
 let cli = new CLI('greet', Path.join(__dirname, 'commands'));
 
+//
+// Support assignment multiple commands root directory
+// 
+// let cli = new CLI('greet', [
+//     Path.join(__dirname, 'commands'),
+//     Path.join(__dirname, 'commands2'),
+//     {
+//         dir: Path.join(__dirname, 'commands'),
+//         title: "EXTEND SUBCOMMANDS", // set this group subcommands caption
+//     }
+// ]);
+
 // Clime in its core provides an object-based command-line infrastructure.
 // To have it work as a common CLI, a shim needs to be applied:
 let shim = new Shim(cli);
 shim.execute(process.argv);
 ```
+
 
 **src/commands/default.ts**
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -98,14 +98,11 @@ export class CLI {
                 if (!TargetCommand.decorated) {
                     throw new TypeError(`Command defined in module "${path}" does not seem to be intialized, make sure to decorate it with \`@command()\``);
                 }
-                console.log("1")
                 TargetCommand.path = path;
                 TargetCommand.sequence = sequence;
 
                 let argsParser = new ArgsParser(TargetCommand);
-                console.log("2")
                 let parsedArgs = await argsParser.parse(sequence, args, cwd);
-                console.log("3")
 
                 if (!parsedArgs) {
                     if (sequence.length == 1) {

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -98,15 +98,21 @@ export class CLI {
                 if (!TargetCommand.decorated) {
                     throw new TypeError(`Command defined in module "${path}" does not seem to be intialized, make sure to decorate it with \`@command()\``);
                 }
-
+                console.log("1")
                 TargetCommand.path = path;
                 TargetCommand.sequence = sequence;
 
                 let argsParser = new ArgsParser(TargetCommand);
+                console.log("2")
                 let parsedArgs = await argsParser.parse(sequence, args, cwd);
+                console.log("3")
 
                 if (!parsedArgs) {
-                    return await HelpInfo.build({ TargetCommand });
+                    if (sequence.length == 1) {
+                        return await this.getHelp();
+                    } else {
+                        return await HelpInfo.build({ TargetCommand });
+                    }
                 }
 
                 let command = new TargetCommand();
@@ -136,10 +142,10 @@ export class CLI {
         }
 
         let helpInfo: HelpInfo;
-        
-        // 如果未找到任何子命令，并且还是多roots情况，需要显示所有subcommands的帮助信息
-        if (sequence.length == 1 && this.roots.length > 1) {
-            helpInfo = await HelpInfo.buildMulti(this.name, this.roots);
+        console.log(sequence);
+        // 如果未找到任何子命令，需要显示所有subcommands的帮助信息
+        if (sequence.length == 1) {
+            helpInfo = await this.getHelp();
         } else {
             helpInfo = await HelpInfo.build({ dir: path, description });
         }

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -139,7 +139,6 @@ export class CLI {
         }
 
         let helpInfo: HelpInfo;
-        console.log(sequence);
         // 如果未找到任何子命令，需要显示所有subcommands的帮助信息
         if (sequence.length == 1) {
             helpInfo = await this.getHelp();

--- a/src/core/command/help.ts
+++ b/src/core/command/help.ts
@@ -236,6 +236,7 @@ ${buildTableOutput(optionRows, { indent: 4, spaces: ' - ' })}`
 
     async buildTextForSubCommands(targets: { dir: string; title?: string }[]): Promise<void> {
         let rows: TableRow[] = [];
+        let subcommandMap: Map<string, boolean> = new Map();
 
         await v.each(targets, async (target, index) => {
             let subCommandTableRows = await HelpInfo.getSubCommandTabbleRows(target.dir);
@@ -250,7 +251,26 @@ ${buildTableOutput(optionRows, { indent: 4, spaces: ' - ' })}`
             }
         });
         
+
         if (rows.length) {
+            // 处理同名子命令的筛选
+            for (let i = rows.length - 1; i >= 0; i--) {
+                let row = rows[i];
+                let subcommandName = row[0] as string;
+
+                if (row[0] == TABLE_CAPTION_FLAG) {
+                    continue;
+                }
+
+                if (subcommandMap.has(subcommandName)) {
+                    rows.splice(i, 1);
+                    continue;
+                }
+
+                subcommandMap.set(subcommandName, true);
+                rows[i].splice(0, 1);
+            }
+
             this.texts.push(buildTableOutput(rows, { indent: 4, spaces: ' - ' }));
         }
     }
@@ -273,6 +293,7 @@ ${buildTableOutput(optionRows, { indent: 4, spaces: ' - ' })}`
                 }
 
                 return [
+                    subcommand.name,
                     subcommandNamesStr,
                     subcommand.brief
                 ];
@@ -313,6 +334,7 @@ ${buildTableOutput(optionRows, { indent: 4, spaces: ' - ' })}`
                 }
 
                 return [
+                    name,
                     Chalk.bold(name),
                     description
                 ] as TableRow;

--- a/src/examples/multi-root/cli.ts
+++ b/src/examples/multi-root/cli.ts
@@ -3,7 +3,7 @@ import { CLI, Shim } from '../../';
 
 let cli = new CLI('greet', [
     Path.join(__dirname, './commands'),
-    Path.join(__dirname, './extend-commands')
+    { dir: Path.join(__dirname, './extend-commands'), title: "EXTEND-COMMANDS" }
 ]);
 
 let shim = new Shim(cli);

--- a/src/examples/multi-root/cli.ts
+++ b/src/examples/multi-root/cli.ts
@@ -1,0 +1,10 @@
+import * as Path from 'path';
+import { CLI, Shim } from '../../';
+
+let cli = new CLI('greet', [
+    Path.join(__dirname, './commands'),
+    Path.join(__dirname, './extend-commands')
+]);
+
+let shim = new Shim(cli);
+shim.execute(process.argv);

--- a/src/examples/multi-root/commands/default.ts
+++ b/src/examples/multi-root/commands/default.ts
@@ -1,0 +1,23 @@
+import * as Path from 'path';
+
+export const description = `\
+     _ _
+ ___| |_|_____ ___
+|  _| | |     | -_|
+|___|_|_|_|_|_|___|
+`;
+
+export const subcommands = [
+    {
+        name: 'install',
+        alias: 'i',
+        brief: 'Show useless message of installation',
+        filename: '../../multi-level/commands/package/install.js'
+    },
+    {
+        name: 'view',
+        aliases: ['show', 'lookup'],
+        brief: 'Show useless message of viewing',
+        filename: '../../multi-level/commands/package/view.js'
+    }
+];

--- a/src/examples/multi-root/extend-commands/default.ts
+++ b/src/examples/multi-root/extend-commands/default.ts
@@ -5,5 +5,10 @@ export const subcommands = [
         name: 'list',
         alias: 'l',
         brief: 'Show useless message of listting'
+    },
+    {
+        name: 'view',
+        alias: ['show', 'lookup'],
+        brief: 'Show useless message of viewing'
     }
 ];

--- a/src/examples/multi-root/extend-commands/default.ts
+++ b/src/examples/multi-root/extend-commands/default.ts
@@ -1,0 +1,9 @@
+export const description = `extend commands`;
+
+export const subcommands = [
+    {
+        name: 'list',
+        alias: 'l',
+        brief: 'Show useless message of listting'
+    }
+];

--- a/src/examples/multi-root/extend-commands/list.ts
+++ b/src/examples/multi-root/extend-commands/list.ts
@@ -1,0 +1,16 @@
+import {
+    command,
+    metadata,
+    Command
+} from '../../../';
+
+@command({
+    brief: 'listing installed packages.'
+
+})
+export default class extends Command {
+    @metadata
+    execute() {
+        return `Guess what, [clime, villa, thenfail, ...].`;
+    }
+}

--- a/src/examples/multi-root/extend-commands/view.ts
+++ b/src/examples/multi-root/extend-commands/view.ts
@@ -1,0 +1,21 @@
+import {
+    command,
+    param,
+    Command
+} from '../../../';
+
+@command({
+    brief: '[extend] View package information.'
+
+})
+export default class extends Command {
+    execute(
+        @param({
+            required: true,
+            description: 'Name of package to view.'
+        })
+        name: string
+    ) {
+        return `Guess what, try extend-command \`npm view ${name}\`.`;
+    }
+}

--- a/src/test/command-locating-cases/multiple-root/commands/biu.ts
+++ b/src/test/command-locating-cases/multiple-root/commands/biu.ts
@@ -1,0 +1,16 @@
+import * as assert from 'assert';
+
+import {
+    command,
+    Command,
+    metadata
+} from '../../../../';
+
+
+@command()
+export default class TestCommand extends Command {
+    @metadata
+    execute() {
+        return 'biu';
+    }
+}

--- a/src/test/command-locating-cases/multiple-root/commands/default.ts
+++ b/src/test/command-locating-cases/multiple-root/commands/default.ts
@@ -1,0 +1,1 @@
+export const description = 'Foo!';

--- a/src/test/command-locating-cases/multiple-root/extend-commands/default.ts
+++ b/src/test/command-locating-cases/multiple-root/extend-commands/default.ts
@@ -1,0 +1,1 @@
+export const description = 'Extend!';

--- a/src/test/command-locating-cases/multiple-root/extend-commands/pia.ts
+++ b/src/test/command-locating-cases/multiple-root/extend-commands/pia.ts
@@ -1,0 +1,16 @@
+import * as assert from 'assert';
+
+import {
+    command,
+    Command,
+    metadata
+} from '../../../../';
+
+
+@command()
+export default class TestCommand extends Command {
+    @metadata
+    execute() {
+        return 'extend/pia';
+    }
+}

--- a/src/test/command-locating.ts
+++ b/src/test/command-locating.ts
@@ -109,4 +109,74 @@ describe('Command Locating', () => {
                 .should.eventually.equal(`${label}/foo/pia`);
         });
     });
+
+    describe('Multi-root Commands', () => {
+        before(() => {
+            cli = new CLI('greet', [
+                Path.join(__dirname, './command-locating-cases/multiple-root/commands'),
+                Path.join(__dirname, './command-locating-cases/multiple-root/extend-commands'),
+            ]);
+        });
+
+        it('Help info', () => {
+            return cli
+                .getHelp()
+                .then(helpInfo => {
+                    helpInfo.text.should.contain('Foo!');
+                    helpInfo.text.should.contain('biu');
+                    helpInfo.text.should.contain('pia');
+                });
+        });
+
+        it('Should locate `commands/biu.js`', () => {
+            return cli
+                .execute(['biu'])
+                .catch((helpInfo: HelpInfo) => {
+                    throw new Error('Should not fulfill');
+                });
+        });
+
+        it('Should locate `extend-commands/pia.js`', () => {
+            return cli
+                .execute(['pia'])
+                .catch((helpInfo: HelpInfo) => {
+                    throw new Error('Should not fulfill');
+                });
+        });
+    });
+
+    describe('Multi-root single command and root title', () => {
+        before(() => {
+            cli = new CLI('greet', [
+                Path.join(__dirname, './command-locating-cases/single'),
+                { dir: Path.join(__dirname, './command-locating-cases/multiple-root/extend-commands'), title: "EXTEND COMMANDS" },
+            ]);
+        });
+
+        it('Help info', () => {
+            return cli
+                .getHelp()
+                .then(helpInfo => {
+                    helpInfo.text.should.contain('greet');
+                    helpInfo.text.should.contain('EXTEND COMMANDS');
+                    helpInfo.text.should.contain('pia');
+                });
+        });
+        
+        it('Should locate `single/default.js`', () => {
+            return cli
+                .execute(['hello'])
+                .then((v) => {
+                    v.should.contain('single');
+                })
+        });
+
+        it('Should locate `extend-commands/pia.js`', () => {
+            return cli
+                .execute(['pia'])
+                .catch((helpInfo: HelpInfo) => {
+                    throw new Error('Should not fulfill');
+                });
+        });
+    });
 });

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -2,6 +2,7 @@ import * as Chalk from 'chalk';
 
 export type TableRow = (string | undefined)[];
 
+export const TABLE_CAPTION_FLAG = 'TABLE_OUTPUT_CAPTION_FLAG';
 export function buildTableOutput(rows: TableRow[], {
     spaces = 4 as string | number,
     indent = 0 as string | number
@@ -10,6 +11,10 @@ export function buildTableOutput(rows: TableRow[], {
 
     for (let row of rows) {
         let lastNoneEmptyIndex = 0;
+
+        if (row[0] == TABLE_CAPTION_FLAG) {
+            continue;
+        }
 
         for (let i = 0; i < row.length; i++) {
             let text = row[i] || '';
@@ -36,8 +41,12 @@ export function buildTableOutput(rows: TableRow[], {
         new Array(indent + 1).join(' ');
 
     return rows
-        .map(row => {
+        .map((row, index) => {
             let line = indentStr;
+
+            if (row[0] == TABLE_CAPTION_FLAG) {
+                return (index > 0 ? '\n' : '') + row[1] + '\n';
+            }
 
             for (let i = 0; i < row.length; i++) {
                 let text = row[i] || '';


### PR DESCRIPTION
#5

- 添加对一级子命令的多目录的支持
- 新改动 完全兼容 原先的使用方式

在多个一级子命令目录被设置的情况，列表中 后面项目 子命令定义 会覆盖掉 前面项目中同名的子命令定义

