### PR TITLE
修复 maxTextLengths 包含 NaN 值的问题

### DIFF
--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -15,11 +15,9 @@ export function buildTableOutput(rows: TableRow[], {
       let text = row[i] || '';
       let textLength = Chalk.stripColor(text).length;
 
-      if (!textLength) {
-        continue;
+      if (textLength) {
+        lastNoneEmptyIndex = i;
       }
-
-      lastNoneEmptyIndex = i;
 
       if (maxTextLengths.length > i) {
         maxTextLengths[i] = Math.max(maxTextLengths[i], textLength);


### PR DESCRIPTION
```
Math.max(undefined, 1); // NaN

// -
Math.max(maxTextLengths[i] , textLength)
在执行到上面这条语句时 maxTextLengths[i] 的值可能是 undefined
```