### PR TITLE
Add custom default command name and extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /test/baseman/output/
 
 npm-debug.log
+yarn-error.log

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -285,7 +285,10 @@ instead of "${definition.name}"`);
     let contexts: SubcommandSearchContext[] = await v.map(
       this.roots,
       async root => {
-        let path: string | undefined = Path.join(root.path, `${CLI.commandModuleDefaultName}${CLI.commandModuleExtension}`);
+        let path: string | undefined = Path.join(
+          root.path,
+          CLI.commandModuleDefaultFileName,
+        );
         path = (await existsFile(path)) ? path : undefined;
 
         let module: CommandModule | undefined;
@@ -397,24 +400,34 @@ instead of "${definition.name}"`);
   }
 
   /**
-   * The name of the default sub-command module
-   * @example <caption>Overriding</caption>
+   * The name of the default sub-command module.
+   *
+   * E.g.:
+   *
    * ```ts
-   * import { CLI } from 'clime';
-   * CLI.commandModuleDefaultName = 'mySpecialDefaultName'
+   * import {CLI} from 'clime';
+   *
+   * CLI.commandModuleDefaultName = 'mySpecialDefaultName';
    * ```
    */
-  static commandModuleDefaultName: string = 'default';
+  static commandModuleDefaultName = 'default';
 
   /**
-   * The extension to use when looking up sub-command modules
-   * @example <caption>Overriding</caption>
+   * The extension to use when looking up sub-command modules.
+   *
+   * E.g.:
+   *
    * ```ts
-   * import { CLI } from 'clime';
+   * import {CLI} from 'clime';
+   *
    * CLI.commandModuleExtension = '.cjs'
    * ```
    */
-  static commandModuleExtension: string = '.js';
+  static commandModuleExtension = '.js';
+
+  static get commandModuleDefaultFileName(): string {
+    return `${this.commandModuleDefaultName}${this.commandModuleExtension}`;
+  }
 
   /**
    * @internal
@@ -437,7 +450,7 @@ instead of "${definition.name}"`);
   ): Promise<CommandEntry | undefined> {
     let possiblePaths = [
       `${searchBase}${CLI.commandModuleExtension}`,
-      Path.join(searchBase, `${CLI.commandModuleDefaultName}${CLI.commandModuleExtension}`),
+      Path.join(searchBase, this.commandModuleDefaultFileName),
     ];
 
     for (let possiblePath of possiblePaths) {

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -449,7 +449,7 @@ instead of "${definition.name}"`);
     searchBase: string,
   ): Promise<CommandEntry | undefined> {
     let possiblePaths = [
-      `${searchBase}${CLI.commandModuleExtension}`,
+      `${searchBase}${this.commandModuleExtension}`,
       Path.join(searchBase, this.commandModuleDefaultFileName),
     ];
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -285,7 +285,7 @@ instead of "${definition.name}"`);
     let contexts: SubcommandSearchContext[] = await v.map(
       this.roots,
       async root => {
-        let path: string | undefined = Path.join(root.path, 'default.js');
+        let path: string | undefined = Path.join(root.path, `${CLI.commandModuleDefaultName}${CLI.commandModuleExtension}`);
         path = (await existsFile(path)) ? path : undefined;
 
         let module: CommandModule | undefined;
@@ -397,6 +397,26 @@ instead of "${definition.name}"`);
   }
 
   /**
+   * The name of the default sub-command module
+   * @example <caption>Overriding</caption>
+   * ```ts
+   * import { CLI } from 'clime';
+   * CLI.commandModuleDefaultName = 'mySpecialDefaultName'
+   * ```
+   */
+  static commandModuleDefaultName: string = 'default';
+
+  /**
+   * The extension to use when looking up sub-command modules
+   * @example <caption>Overriding</caption>
+   * ```ts
+   * import { CLI } from 'clime';
+   * CLI.commandModuleExtension = '.cjs'
+   * ```
+   */
+  static commandModuleExtension: string = '.js';
+
+  /**
    * @internal
    * Get subcommands definition written as `export subcommands = [...]`.
    */
@@ -416,8 +436,8 @@ instead of "${definition.name}"`);
     searchBase: string,
   ): Promise<CommandEntry | undefined> {
     let possiblePaths = [
-      `${searchBase}.js`,
-      Path.join(searchBase, 'default.js'),
+      `${searchBase}${CLI.commandModuleExtension}`,
+      Path.join(searchBase, `${CLI.commandModuleDefaultName}${CLI.commandModuleExtension}`),
     ];
 
     for (let possiblePath of possiblePaths) {

--- a/src/core/command/help.ts
+++ b/src/core/command/help.ts
@@ -105,17 +105,17 @@ export class HelpInfo implements Printable {
         let path = Path.join(dir, name);
         let stats = await safeStat(path);
 
-        const { commandModuleDefaultName: defaultName, commandModuleExtension: extension } = CLI;
-        const defaultFile = `${defaultName}${extension}`;
-
         if (stats!.isFile()) {
-          if (name === defaultFile || Path.extname(path) !== extension) {
+          if (
+            name === CLI.commandModuleDefaultFileName ||
+            Path.extname(path) !== CLI.commandModuleExtension
+          ) {
             continue;
           }
 
-          name = Path.basename(name, extension);
+          name = Path.basename(name, CLI.commandModuleExtension);
         } else {
-          path = Path.join(path, defaultFile);
+          path = Path.join(path, CLI.commandModuleDefaultFileName);
           stats = await safeStat(path);
         }
 

--- a/src/core/command/help.ts
+++ b/src/core/command/help.ts
@@ -105,14 +105,17 @@ export class HelpInfo implements Printable {
         let path = Path.join(dir, name);
         let stats = await safeStat(path);
 
+        const { commandModuleDefaultName: defaultName, commandModuleExtension: extension } = CLI;
+        const defaultFile = `${defaultName}${extension}`;
+
         if (stats!.isFile()) {
-          if (name === 'default.js' || Path.extname(path) !== '.js') {
+          if (name === defaultFile || Path.extname(path) !== extension) {
             continue;
           }
 
-          name = Path.basename(name, '.js');
+          name = Path.basename(name, extension);
         } else {
-          path = Path.join(path, 'default.js');
+          path = Path.join(path, defaultFile);
           stats = await safeStat(path);
         }
 


### PR DESCRIPTION
This patch allows the customisation of the default command module name and the extension to use for lookups. Depending on the users build they may be using a different extensions for their CommonJS modules. Being able to specify the default command module name allows the user to re-use a nested sub-command as the default command.